### PR TITLE
Make themes static members

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,7 @@ class RapidApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Rapid',
-      theme: Themes().lightMode,
+      theme: Themes.lightMode,
       debugShowCheckedModeBanner: false,
       routes: {
         HomeRoute.routeName: (BuildContext ctx) => HomeRoute(),

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class Themes {
-  ThemeData get lightMode => ThemeData(
+  static ThemeData get lightMode => ThemeData(
         visualDensity: VisualDensity.adaptivePlatformDensity,
         primaryColor: Color(0xFFFC8181),
         accentColor: Color(0xFFFC8181),


### PR DESCRIPTION
This baby PR makes individual themes static members of the `Themes` class, so `Themes` doesn't have to be instantiated.